### PR TITLE
Nix flake: version.txt back to the F* root, remove fstar.install, install doc/tutorial

### DIFF
--- a/.nix/fstar.nix
+++ b/.nix/fstar.nix
@@ -5,25 +5,20 @@ stdenv.mkDerivation {
   pname = "fstar";
   inherit version;
 
-  dontUnpack = true;
-
   buildInputs = [ installShellFiles makeWrapper ];
+
+  src = ./..;
+
+  buildPhase = "true";
 
   installPhase = ''
     mkdir $out
-    cd $out
 
     CP="cp -r --no-preserve=mode"
-    $CP ${fstar-dune}/* .
-    $CP ${ulib}/* .
+    $CP ${fstar-dune}/* $out
+    $CP ${ulib}/* $out
 
-    # FIXME: Why not use `make -C src/ocaml-output install-sides` ?
-    # (after moving the ulib install command back to `install`)
-    mkdir -p share/fstar/doc
-    $CP ${../examples} share/fstar/examples
-    $CP ${../ucontrib} share/fstar/contrib
-    $CP ${../doc/Makefile.include} share/fstar/doc/Makefile.include
-    $CP ${../doc/tutorial} share/fstar/doc/tutorial
+    PREFIX=$out make -C src/ocaml-output install-sides -j $NIX_BUILD_CORES
 
     for binary in $out/bin/*
     do
@@ -31,6 +26,7 @@ stdenv.mkDerivation {
       wrapProgram $binary --prefix PATH ":" ${z3}/bin
     done
 
+    cd $out
     installShellCompletion --bash ${../.completion/bash/fstar.exe.bash}
     installShellCompletion --fish ${../.completion/fish/fstar.exe.fish}
     installShellCompletion --zsh --name _fstar.exe ${

--- a/src/ocaml-output/Makefile
+++ b/src/ocaml-output/Makefile
@@ -128,6 +128,8 @@ install:
 	+$(MAKE) -C $(FSTAR_HOME)
 	@# Install the binary and the binary library
 	cd $(DUNE_SNAPSHOT) && dune install --prefix=$(PREFIX)
+	@# Then the standard library sources and checked files
+	+$(MAKE) -C $(FSTAR_HOME)/ulib install
 	@# Then the rest
 	+$(MAKE) install-sides
 
@@ -137,8 +139,6 @@ install:
 
 .PHONY: install-sides
 install-sides:
-	@# Then the standard library sources and checked files
-	+$(MAKE) -C $(FSTAR_HOME)/ulib install
 	@# Then the examples (those now work from any F* installation flavor, sources, binary package or opam)
 	@# ucontrib is needed by examples/crypto
 	$(call install_dir,examples,share/fstar/examples)


### PR DESCRIPTION
Thank you PNM and @W95psp for your improvements to the updated nix flake! I have a few questions:

* With @mtzguido, we think `version.txt` should stay in the root directory of F*, because it is independent on F* being built with OCaml, and many other projects across Everest (e.g. EverParse) have version.txt in their root directories. (I let Guido say more if needed.) Moreover, it is harmless to have it installed in the user's `lib/fstar`. So, in this PR, I managed to create a derivation, `fstar-pre`, to just copy `version.txt` to the user's `lib/fstar`, so that `fstar-dune` depends on `fstar-pre` and copies it back to its source tree before compiling F*. Once so, `dune` will carry on generating `FStar_Version.ml` following your changes.

* Do we really need to keep `fstar.install` in the `ocaml` snapshot? If so, how can we ensure that it is consistent when new modules are added in the F* sources or ulib? In this PR, I manage to rebuild F* with the nix flake without `fstar.install`

* In this PR, in the `installPhase` of `.nix/fstar.nix`, I also install `doc/tutorial` to reach parity with `make install`. Then, instead of manually copying the files, why not reuse `make -C src/ocaml-output install-sides` (with `ulib` moved back to `make install`) to factor this code out?

Thank you again!